### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.github/workflows/actions_release.yaml
+++ b/.github/workflows/actions_release.yaml
@@ -10,6 +10,10 @@ on:
         description: "Script to run for the release"
         required: false
         default: "npm run all"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: read
@@ -24,3 +28,4 @@ jobs:
     with:
       tag: "${{ github.event.inputs.tag }}"
       script: "${{ github.event.inputs.script }}"
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit-package.yml
+++ b/.github/workflows/audit-package.yml
@@ -13,6 +13,10 @@ on:
       script:
         required: false
         default: "npm run all"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
   schedule:
     - cron: "0 0 * * 1"
@@ -24,6 +28,7 @@ jobs:
       force: ${{ inputs.force || false }}
       base_branch: ${{ inputs.base_branch || 'main' }}
       script: ${{ inputs.script || 'npm run all' }}
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -10,6 +10,10 @@ on:
       script:
         required: false
         default: "npm run all"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: write
@@ -25,3 +29,4 @@ jobs:
       repo-name: "secrets-sync-action"
       base_branch: ${{ inputs.base_branch }}
       script: ${{ inputs.script }}
+      node_version: "${{ inputs.node_version || '24' }}"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Secrets Sync Action
 
 ![Build](https://github.com/step-security/secrets-sync-action/workflows/Build/badge.svg)

--- a/action.yml
+++ b/action.yml
@@ -72,5 +72,5 @@ inputs:
       If this value is set, the action will prefix the secret name with this value.
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -420,22 +420,43 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const main_1 = __nccwpck_require__(3109);
 const core = __importStar(__nccwpck_require__(2186));
+const fs = __importStar(__nccwpck_require__(7147));
 const axios_1 = __importStar(__nccwpck_require__(8757));
 function validateSubscription() {
-    var _a;
+    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
-        const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+        const eventPath = process.env.GITHUB_EVENT_PATH;
+        let repoPrivate;
+        if (eventPath && fs.existsSync(eventPath)) {
+            const eventData = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+            repoPrivate = (_a = eventData === null || eventData === void 0 ? void 0 : eventData.repository) === null || _a === void 0 ? void 0 : _a.private;
+        }
+        const upstream = "jpoehnelt/secrets-sync-action";
+        const action = process.env.GITHUB_ACTION_REPOSITORY;
+        const docsUrl = "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+        core.info("");
+        core.info("\u001b[1;36mStepSecurity Maintained Action\u001b[0m");
+        core.info(`Secure drop-in replacement for ${upstream}`);
+        if (repoPrivate === false)
+            core.info("\u001b[32m\u2713 Free for public repositories\u001b[0m");
+        core.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`);
+        core.info("");
+        if (repoPrivate === false)
+            return;
+        const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+        const body = { action: action || "" };
+        if (serverUrl !== "https://github.com")
+            body.ghes_server = serverUrl;
         try {
-            yield axios_1.default.get(API_URL, { timeout: 3000 });
+            yield axios_1.default.post(`https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`, body, { timeout: 3000 });
         }
         catch (error) {
-            if ((0, axios_1.isAxiosError)(error) && ((_a = error.response) === null || _a === void 0 ? void 0 : _a.status) === 403) {
-                core.error("Subscription is not valid. Reach out to support@stepsecurity.io");
+            if ((0, axios_1.isAxiosError)(error) && ((_b = error.response) === null || _b === void 0 ? void 0 : _b.status) === 403) {
+                core.error(`\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`);
+                core.error(`\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`);
                 process.exit(1);
             }
-            else {
-                core.info("Timeout or API not reachable. Continuing to next step.");
-            }
+            core.info("Timeout or API not reachable. Continuing to next step.");
         }
     });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,52 @@
 import { run } from "./main";
 import * as core from "@actions/core";
+import * as fs from "fs";
 import axios, { isAxiosError } from "axios";
 
 async function validateSubscription(): Promise<void> {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  let repoPrivate: boolean | undefined;
 
+  if (eventPath && fs.existsSync(eventPath)) {
+    const eventData = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+    repoPrivate = eventData?.repository?.private;
+  }
+
+  const upstream = "jpoehnelt/secrets-sync-action";
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+
+  core.info("");
+  core.info("\u001b[1;36mStepSecurity Maintained Action\u001b[0m");
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info("\u001b[32m\u2713 Free for public repositories\u001b[0m");
+  core.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`);
+  core.info("");
+
+  if (repoPrivate === false) return;
+
+  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const body: Record<string, string> = { action: action || "" };
+  if (serverUrl !== "https://github.com") body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, { timeout: 3000 });
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 }
+    );
   } catch (error) {
     if (isAxiosError(error) && error.response?.status === 403) {
       core.error(
-        "Subscription is not valid. Reach out to support@stepsecurity.io"
+        `\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`
+      );
+      core.error(
+        `\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`
       );
       process.exit(1);
-    } else {
-      core.info("Timeout or API not reachable. Continuing to next step.");
     }
+    core.info("Timeout or API not reachable. Continuing to next step.");
   }
 }
 


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (if applicable)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- **Docker/Shell actions**: replaced entrypoint.sh subscription block
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260325T091734Z